### PR TITLE
Changed i18nIm.sequenceShouldSplit for en and de

### DIFF
--- a/locales/de.coffee
+++ b/locales/de.coffee
@@ -206,7 +206,7 @@ i18nIm:
   imageRotated: "Dieses Bild hat eine falsche Orientierung."
   imageNotBlurred: "Dieses Bild ist nicht korrekt verpixelt."
   imageShouldHide: "Dieses Bild sollte nicht gezeigt werden."
-  sequenceShouldSplit: "Diese Bilderfolge soll hier geteilt werden."
+  sequenceShouldSplit: "Diese Bilderfolge soll nach diesem Bild geteilt werden."
   ifMapillaryUser: "Wenn du ein Mapillary Anwender bist, kannst du die Bilder in der 'Bearbeiten' Sektion ändern."
   send: "Senden"
   panorama: "Panorama"

--- a/locales/en.coffee
+++ b/locales/en.coffee
@@ -204,7 +204,7 @@ i18nIm:
   imageRotated: "The image is rotated"
   imageNotBlurred: "The image is not blurred correctly"
   imageShouldHide: "The image should be hidden"
-  sequenceShouldSplit: "The sequence should be split here"
+  sequenceShouldSplit: "The sequence should be split after this image"
   ifMapillaryUser: "If you're a Mapillary user, you can manually hide the image from within the 'Edit' image options"
   send: "Send"
   panorama: "Panorama"


### PR DESCRIPTION
The new message says that "The sequence should be split __after__ this image" instead of a vague "The sequence should be split __here__".

Translations for the other languages are welcome (preferrably as pull request against [floscher/mapillary_localization](//github.com/floscher/mapillary_localization), but a comment in this pull request would also do it).

See mapillary/mapillary_issues#762 for the reasoning behind this change.